### PR TITLE
add kubernetes-networks/

### DIFF
--- a/kubernetes-networks/canary/last_ingress.yaml
+++ b/kubernetes-networks/canary/last_ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: stage
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: always
+spec:
+  rules:
+  - host: lb-ingress.local
+    http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc1
+          servicePort: 8000
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: prod
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary-by-header: never
+spec:
+  rules:
+  - host: lb-ingress.local
+    http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc2
+          servicePort: 8000
+

--- a/kubernetes-networks/canary/web-deploy1.yaml
+++ b/kubernetes-networks/canary/web-deploy1.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: web1 
+    spec:
+      containers:
+      - name: web
+        image: itokareva/web:1.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+---        
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc1
+spec:
+  selector:
+    app: web1
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/canary/web-deploy2.yaml
+++ b/kubernetes-networks/canary/web-deploy2.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web2
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web2 
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: web2 
+    spec:
+      containers:
+      - name: web
+        image: itokareva/web:2.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+---        
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc2
+spec:
+  selector:
+    app: web2 
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+        

--- a/kubernetes-networks/coredns/dns_lb.yaml
+++ b/kubernetes-networks/coredns/dns_lb.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "true"        
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+  - name: dns
+    protocol: TCP
+    port: 53
+    targetPort: 53
+--- 
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "true"
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+  - name: dns
+    protocol: UDP
+    port: 53
+    targetPort: 53
+

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard 
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  namespace: kubernetes-dashboard 
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard 
+        pathType: Prefix
+        backend:
+          service:
+            name: 
+              kubernetes-dashboard
+            port:
+              number: 8443            

--- a/kubernetes-networks/dashboard/dashboard-svc-headless.yaml
+++ b/kubernetes-networks/dashboard/dashboard-svc-headless.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard 
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    k8s-app: kubernetes-dashboard

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.255.1-172.17.255.255 

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: itokareva/web:1.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: ingress-nginx
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: web-svc
-  namespace: ingress-nginx
+#  namespace: ingress-nginx
 spec:
   selector:
     app: web

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
-  Работа с тестовым веб-приложением 
   -   Добавление проверок Pod  
   -   Создание объекта Deployment 
   -   Добавление сервисов в кластер ( ClusterIP )
   -   Включение режима балансировки IPVS
-   Установка MetalLB в Layer2-режиме 
   -  Добавление сервиса LoadBalancer 
   -  Установка Ingress-контроллера и прокси ingress-nginx 
   -  Создание правил Ingress

   Задание со (*)
   Создан сервис LoadBalancer , который открывает доступ к CoreDNS снаружи кластера (позволяет получать записи через внешний IP).
   Сервис работает по протоколам TCP и UDP на одно ip-адресе балансировщика.
   Использована аннотация: metallb.universe.tf/allow-shared-ip

   Задание со (*) Ingress для Dashboard
   Добавлен доступ к kubernetes-dashboard через наш Ingress-прокси:
   сервис доступен через префикс /dashboard.

   Задание со (*) Canary для Ingress
   Реализовано канареечное развертывание с помощью ingress-nginx:
   часть трафика перенаправляется на выделенную группу подов по HTTP-заголовку

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist
 - [HW4] Выставил label с номером домашнего задания
 - [kubernetes-network] Выставил label с темой домашнего задания
