### PR TITLE
add kubernetes-volumes/

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,22 @@ curl http://lb-ingress.local/web/index.html
 <pre><font color=white>011101001111101111001000011101100000111000011001
 </details>
 
+</details>
+
+<details>
+  <summary>## Домашняя работа 5</summary>
+
+  ## Хранение данных в Kubernetes.Volumes, Storages, Statefull-приложения
+
+В этом ДЗ мы развернем StatefulSet c MinIO  - локальным S3 хранилищем.
+
+Задание со (*) 
+
+В конфигурации нашего StatefulSet данные указаны в открытом виде, что не безопасно. Поместите данные в SECRETS  и настройте конфигурацию на их использование.
+Созданы новые файлы minio_secret.yaml и miniostatefulset.yaml.
+Запуститься под с MinIO - запустился с применением новой конфигурации.
+
+</details>
 
 
 

--- a/kubernetes-volumes/minio-headlessservice.yaml
+++ b/kubernetes-volumes/minio-headlessservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio_secret.yaml
+++ b/kubernetes-volumes/minio_secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio 
+type: kubernetes.io/basic-auth
+stringData:
+  username: minio
+  password: minio123

--- a/kubernetes-volumes/miniostatefulset.yaml
+++ b/kubernetes-volumes/miniostatefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/miniostatefulset_secret.yaml
+++ b/kubernetes-volumes/miniostatefulset_secret.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio 
+              key: username 
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: password
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ №5
   Хранение данных в Kubernetes.Volumes, Storages, Statefull-приложения

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - В этом ДЗ мы развернем StatefulSet c MinIO  - локальным S3 хранилищем.
 - Задание со (*)
    В конфигурации нашего StatefulSet данные указаны в открытом виде, что не безопасно. Поместите данные в SECRETS  
   и настройте конфигурацию на их использование.
   Созданы новые файлы minio_secret.yaml и miniostatefulset.yaml.
   Запуститься под с MinIO - запустился с применением новой конфигурации.

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist
 - [HW5] Выставил label с номером домашнего задания
 - [kubernetes-volumes] Выставил label с темой домашнего задания
