### PR TITLE
add kubernetes-storage/

### DIFF
--- a/kubernetes-storage/hw/csi-app.yaml
+++ b/kubernetes-storage/hw/csi-app.yaml
@@ -1,0 +1,16 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-csi-app
+spec:
+  containers:
+    - name: my-frontend
+      image: busybox
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: [ "sleep", "1000000" ]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: csi-pvc # defined in csi-pvc.yaml

--- a/kubernetes-storage/hw/csi-app.yaml
+++ b/kubernetes-storage/hw/csi-app.yaml
@@ -1,7 +1,7 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: my-csi-app
+  name: storage-pod 
 spec:
   containers:
     - name: my-frontend
@@ -13,4 +13,4 @@ spec:
   volumes:
     - name: my-csi-volume
       persistentVolumeClaim:
-        claimName: csi-pvc # defined in csi-pvc.yaml
+        claimName: storage-pvc # defined in csi-pvc.yaml

--- a/kubernetes-storage/hw/csi-pvc.yaml
+++ b/kubernetes-storage/hw/csi-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-hostpath-sc # defined in csi-storageclass.yaml

--- a/kubernetes-storage/hw/csi-pvc.yaml
+++ b/kubernetes-storage/hw/csi-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-pvc
+  name: storage-pvc 
 spec:
   accessModes:
   - ReadWriteOnce

--- a/kubernetes-storage/hw/csi-restore.yaml
+++ b/kubernetes-storage/hw/csi-restore.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: csi-pvc
+  name: storage-pvc 
 spec:
   storageClassName: csi-hostpath-sc
   dataSource:

--- a/kubernetes-storage/hw/csi-restore.yaml
+++ b/kubernetes-storage/hw/csi-restore.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    name: new-snapshot-demo
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/hw/csi-snapshot-v1beta1.yaml
+++ b/kubernetes-storage/hw/csi-snapshot-v1beta1.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: new-snapshot-demo
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source:
+    persistentVolumeClaimName: csi-pvc

--- a/kubernetes-storage/hw/csi-snapshot-v1beta1.yaml
+++ b/kubernetes-storage/hw/csi-snapshot-v1beta1.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   volumeSnapshotClassName: csi-hostpath-snapclass
   source:
-    persistentVolumeClaimName: csi-pvc
+    persistentVolumeClaimName: storage-pvc 

--- a/kubernetes-storage/hw/csi-storageclass.yaml
+++ b/kubernetes-storage/hw/csi-storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true


### PR DESCRIPTION
# Выполнено ДЗ №11
# CSI. Обзор подсистем хранения данных в Kubernetes

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Установлена версия 1.18.1 миникуба
 - Устанавливаем csi-hostpath-driver
 - Создаем storage class csi-hostpath-sc
 - Создаем pvc csi-hostpath-sc. Вместе с ней создается и pv
 - Создаем под my-csi-app, заходим в него и создаем файлик /data/hello-world
 - Создаем snapshot c pvc
 - Удаляем pvc csi-pvc:
 - Создаем pvs из snapshot
 - Поднимаем под my-csi-app и проверяем, что файлик /data/hello-world на месте

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist
 - [HW#11] Выставил label с номером домашнего задания
 - [kubernetes-storage] Выставил label с темой домашнего задания
